### PR TITLE
Updating steps for package inventory

### DIFF
--- a/theory_md/package-inventory.md
+++ b/theory_md/package-inventory.md
@@ -27,7 +27,7 @@ Before viewing package inventory, it must first be enabled. Once enabled, you ca
 To collect package inventory, you’ll need to enable it first for all agents. You’ll then need to perform two Puppet runs to begin collecting package inventory. The first run will apply the setting to your nodes and _enable_ package inventory collection. The second run will _collect_ package inventory for the first time.
 
 
-1. Open the Puppet Enterprise Web Console at <span style="text-decoration:underline;">https://&lt;IP address or FQDN></span> and login with username **admin** and the password you set earlier.
+1. Open the Puppet Enterprise Web Console at <span style="text-decoration:underline;">https://&lt;IP address or FQDN></span> and login with a username and password which has admin permissions.
 2. Under Inventory on the side bar, click the Node groups
 3. Expand the **PE infrastructure** by clicking the **⊞** sign, then click the **PE Agent** node group.
 4. Navigate to the **Classes** tab

--- a/theory_md/package-inventory.md
+++ b/theory_md/package-inventory.md
@@ -27,15 +27,17 @@ Before viewing package inventory, it must first be enabled. Once enabled, you ca
 To collect package inventory, you’ll need to enable it first for all agents. You’ll then need to perform two Puppet runs to begin collecting package inventory. The first run will apply the setting to your nodes and _enable_ package inventory collection. The second run will _collect_ package inventory for the first time.
 
 
-1. Expand the **PE infrastructure** by clicking the **⊞** sign, then click the **PE Agent** node group.
-2. Navigate to the **Classes** tab
-3. In the **puppet_enterprise::profile::agent** class, click **Parameter name** and select **package_inventory_enabled** from the list
-4. Set its **Value** to **true**.
-5. Click **Add to node group**
-6. To save the changes, click **Commit 1 change** in the lower right hand corner of the screen. 
-7. Ensure you’re still within the **PE Agent** node group and in the top right corner click **Run > Puppet**
-8. Once in the **Run Puppet** screen, click the **Run job** button on the bottom right hand corner of the screen - Wait for the Puppet run to complete.
-9. Once the Puppet run is complete, click the **Run again** button on the top right hand corner of the screen and click **Run job** again
+1. Open the Puppet Enterprise Web Console at <span style="text-decoration:underline;">https://&lt;IP address or FQDN></span> and login with username **admin** and the password you set earlier.
+2. Under Inventory on the side bar, click the Node groups
+3. Expand the **PE infrastructure** by clicking the **⊞** sign, then click the **PE Agent** node group.
+4. Navigate to the **Classes** tab
+5. In the **puppet_enterprise::profile::agent** class, click **Parameter name** and select **package_inventory_enabled** from the list
+6. Set its **Value** to **true**.
+7. Click **Add to node group**
+8. To save the changes, click **Commit 1 change** in the lower right hand corner of the screen. 
+9. Ensure you’re still within the **PE Agent** node group and in the top right corner click **Run > Puppet**
+10. Once in the **Run Puppet** screen, click the **Run job** button on the bottom right hand corner of the screen - Wait for the Puppet run to complete.
+11. Once the Puppet run is complete, click the **Run again** button on the top right hand corner of the screen and click **Run job** again
 
 
 You can now view package information across your nodes within PE.


### PR DESCRIPTION
Adding steps to help new users to Puppet find the correct location. I found this missing step was slightly confusing and might be useful to have a complete click by click when using the web console. 